### PR TITLE
Fix Lintian warnings

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: pi-top <deb-maintainers@pi-top.com>
 Build-Depends: debhelper-compat (= 12),
   dh-sequence-python3,
-Standards-Version: 4.5.0
+Standards-Version: 4.5.1
 Homepage: https://pi-top.com
 
 Package: pt-further-link

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,1 +1,0 @@
-pt-further-link source: testsuite-autopkgtest-missing


### PR DESCRIPTION
Lintian output to suppress:
```
I: pt-further-link source: out-of-date-standards-version 4.5.0 (released 2020-01-20) (current is 4.5.1)
I: pt-further-link source: unused-override testsuite-autopkgtest-missing
```
