### PR TITLE
Drop unused `override_dh_installsystemd`

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -23,6 +23,3 @@ override_dh_clean:
 	rm -rf extra/fl.dat extra/key.aes.pem
 
 	dh_clean
-
-override_dh_installsystemd:
-	dh_installsystemd --name=further-link


### PR DESCRIPTION
Because the service has the same name as the package, this is not needed.