### PR TITLE
Set language to english when running bash commands

### DIFF
--- a/further_link/endpoint/apt_version.py
+++ b/further_link/endpoint/apt_version.py
@@ -1,9 +1,8 @@
 import json
 import re
-from shlex import split
-from subprocess import CalledProcessError, check_output
 
 from aiohttp import web
+from pitop.common.command_runner import run_command
 
 
 async def apt_version(request):
@@ -13,9 +12,9 @@ async def apt_version(request):
 
 def apt_cache_installed(pkg_name):
     try:
-        command = split(f"apt-cache policy {pkg_name}")
-        output = check_output(command).decode("utf-8")
+        command = f"apt-cache policy {pkg_name}"
+        output = run_command(command, timeout=5)
         match = re.search("Installed: (.*)", output)
         return match.group(1) if match else None
-    except (CalledProcessError, FileNotFoundError):
+    except Exception:
         return None


### PR DESCRIPTION
Ticket: https://pi-top.atlassian.net/browse/FUR-2384

### Summary

Set the `LANG` environment variable to `en_US.UTF-8` to print out the output of the command being run in english.

Also:
- Replaced `check_output` with `run` since it allows to set the environment of the command being run.
- Imported a simplified version of `run_command` from the SDK.

This solution is similar to https://github.com/pi-top/pi-top-Python-SDK/pull/511 and https://github.com/pi-top/pi-top-Python-SDK/pull/510

### How to test?

- Change the language of your OS using `raspi-config` or by running the onboarding again (in `http://192.168.64.1/onboarding`)
- Reboot your pi-top
- Check the output of `https://192.168.64.1:8028/version/apt/further-link`... e.g.:
```
curl https://192.168.64.1:8028/version/apt/further-link -k
{"version": null}
```
- Download this PR artifacts, unzip the .deb files and scp them into your pi-top.
- ssh into your pi-top and install the debs with `sudo apt install ./*.deb` from the directory where you scp'ed the deb files.
- Restart the further-link service with `sudo systemctl restart further-link`
- Check the output of `https://192.168.64.1:8028/version/apt/further-link`... This time you should get the version of the package that's installed in the system. e.g.:
```
curl https://192.168.64.1:8028/version/apt/further-link -k
{"version": "5.0.1-2~17.gbpa84cdc"}
```