### PR TITLE
novnc backend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
             /bin/bash -c " \
               apt-get update && \
               apt-get install -y python3 python3-pip && \
+              pip3 install -U pip && \
               cd /${{ github.event.repository.name }} && \
               pip3 install .[test] && \
               pytest -v --cov=further_link && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,27 @@
-FROM python:3.9-bullseye
+FROM debian:bullseye
 
-WORKDIR /tmp/further-link
+RUN apt-get update && \
+    apt-get install -y python3-tk python3-pip && \
+    apt-get clean
+
+RUN pip3 install -U pip
+
+RUN apt-get update && \
+    apt-get install -y novnc net-tools procps xvfb x11vnc && \
+    apt-get clean
+
+WORKDIR /further-link
 
 COPY pyproject.toml setup.py setup.cfg MANIFEST.in ./
+COPY debian debian
 COPY LICENSE README.rst ./
 COPY further_link further_link
 COPY scripts scripts
-RUN pip install .
+
+RUN pip3 install .
 
 ENV FURTHER_LINK_NOSSL=true
 
 EXPOSE 8028
+EXPOSE 60000-61000
 CMD [ "further-link" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /tmp/further-link
 COPY pyproject.toml setup.py setup.cfg MANIFEST.in ./
 COPY LICENSE README.rst ./
 COPY further_link further_link
+COPY scripts scripts
 RUN pip install .
 
 ENV FURTHER_LINK_NOSSL=true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include further_link *
+recursive-include scripts *
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/debian/control
+++ b/debian/control
@@ -27,6 +27,8 @@ Depends: ${misc:Depends},
 Suggests:
 # Used for device IDs in serial
  pi-topd,
+# Required by OpenSSL
+ libffi7,
 Description: pi-top Further Link
  Connect to further.pi-top.com from a browser, allowing you to run
  your own Python projects on a pi-top remotely (as long as you are

--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,16 @@ Package: further-link
 Architecture: all
 Depends: ${misc:Depends},
  ${python3:Depends},
+# To serve VNC over http
+ novnc,
+# net-tools includes netstat which is an undeclared dependency of novnc
+ net-tools,
+# procps includes ps which is an undeclared dependency of novnc
+ procps,
+# To create virtual display
+ xvfb,
+# VNC server
+ x11vnc,
 Suggests:
 # Used for device IDs in serial
  pi-topd,

--- a/debian/further-link.lintian-overrides
+++ b/debian/further-link.lintian-overrides
@@ -1,2 +1,3 @@
 further-link: no-manual-page usr/bin/further-link
+further-link: no-manual-page usr/bin/further-link-vnc
 further-link: no-manual-page usr/bin/start-further

--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -6,3 +6,4 @@ aiohttp_cors python3-aiohttp-cors; PEP386
 # Numpy in Debian has epoch version 1
 numpy python3-numpy; s/^/1:/
 Pillow python3-pil; PEP386
+pyOpenSSL python3-openssl; PEP386

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,10 +12,16 @@ The project requires Python 3.7+. The dependencies, command line tool and
 associated python package can be installed (optionally in a virtualenv) in a
 clone of the repo by running:
 ```
-pip3 install -e .
+pip3 install -e ".[test]"
+sudo mk-build-deps -i
 ```
 
-Then run the server for development with:
+Run the tests with:
+```
+pytest
+```
+
+Run the server for development with:
 ```
 FURTHER_LINK_NOSSL=1 python3 further_link/__main__.py
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -260,7 +260,7 @@ Message types accepted by the server are:
 Message types sent from the server are:
 ```
 {
- "type":"[pong|error|started|stopped|stdout|stderr|keylisten]",
+ "type":"[pong|error|started|stopped|stdout|stderr|novnc|video|keylisten]",
  "data": {...},
  "process": "id"
 }
@@ -287,10 +287,16 @@ Basic:
     not absolute, it is assumed to be relative to the further link working
     directory described above.
 
+    A 'novnc' boolean option can also be passed in the start data to create a
+    virtual display for the process, attach a vnc server to it and serve it via
+    the novnc websocket proxy, for viewing from a browser. When a window is
+    detected on the virtual display, a 'novnc' response will be sent to inform
+    the browser of the activity and how to view it.
+
     e.g.
     `data: {code:"print('hi')"}`
     `data: {code:"print('hi')", path: "myproject"}`
-    `data: {path: "myproject/run.py"}`
+    `data: {path: "myproject/run.py", novnc: true}`
     `data: {path: "/home/pi/run.py"}`
 
 - `started` response is sent after a successful process `start`, has no data.
@@ -306,6 +312,11 @@ Basic:
 <br>
 
 Advanced
+- `novnc` response is sent by the server with data.port containing a port
+    number and data.path containing a url path. These can be used to construct
+    the url of a vnc client to view graphical output of the process.
+<br>
+
 - `video` response is sent by the server with data.output containing a base64
     encoded mjpeg frame for the client to render as a video feed.
 <br>

--- a/further_link/__main__.py
+++ b/further_link/__main__.py
@@ -11,6 +11,7 @@ from further_link.endpoint.apt_version import apt_version
 from further_link.endpoint.run import run as run_handler
 from further_link.endpoint.run_py import run_py
 from further_link.endpoint.upload import upload
+from further_link.util import vnc
 from further_link.util.ssl_context import ssl_context
 from further_link.version import __version__
 
@@ -66,6 +67,7 @@ def create_app():
 
 @click.command()
 def main():
+    vnc.create_ssl_certificate()
     return web.run_app(
         create_app(),
         port=port(),

--- a/further_link/endpoint/run.py
+++ b/further_link/endpoint/run.py
@@ -96,8 +96,8 @@ class RunManager:
             logging.exception(f"{self.id} Bad Message")
             await self.send("error", {"message": "Bad message"})
 
-        except Exception:
-            logging.exception(f"{self.id} Message Exception")
+        except Exception as e:
+            logging.exception(f"{self.id} Message Exception: {e}")
             await self.send("error", {"message": "Message Exception"})
 
     async def add_handler(self, process_id, runner, path, code, novnc):

--- a/further_link/runner/exec_process_handler.py
+++ b/further_link/runner/exec_process_handler.py
@@ -17,7 +17,7 @@ class ExecProcessHandler(ProcessHandler):
         # create path directories if they don't already exist
         os.makedirs(os.path.dirname(path), exist_ok=True)
 
-        entrypoint = path if code is None else os.path.join(path, self.id)
+        entrypoint = path if code is None else os.path.join(path, f"exec-{self.id}")
 
         # create a temporary file to execute if code is provided
         if code is not None:

--- a/further_link/runner/exec_process_handler.py
+++ b/further_link/runner/exec_process_handler.py
@@ -11,7 +11,7 @@ further_link_module_path = os.path.join(dirname, "lib")
 
 
 class ExecProcessHandler(ProcessHandler):
-    async def start(self, path, code=None):
+    async def start(self, path, code=None, novnc=False):
         path = get_absolute_path(path, get_working_directory(self.user))
 
         # create path directories if they don't already exist
@@ -31,7 +31,7 @@ class ExecProcessHandler(ProcessHandler):
 
         work_dir = os.path.dirname(entrypoint)
 
-        await super().start(command, work_dir)
+        await super().start(command, work_dir, novnc=novnc)
 
     async def _clean_up(self):
         try:

--- a/further_link/runner/process_handler.py
+++ b/further_link/runner/process_handler.py
@@ -8,6 +8,7 @@ from shlex import split
 import aiofiles
 
 from ..util.async_helpers import ringbuf_read, timeout
+from ..util.id_generator import IdGenerator
 from ..util.ipc import async_ipc_send, async_start_ipc_server, ipc_cleanup
 from ..util.sdk import get_first_display
 from ..util.terminal import set_winsize
@@ -20,6 +21,7 @@ from ..util.user_config import (
     get_working_directory,
     user_exists,
 )
+from ..util.vnc import start_vnc, stop_vnc
 
 SERVER_IPC_CHANNELS = [
     "video",
@@ -31,15 +33,20 @@ class InvalidOperation(Exception):
     pass
 
 
+id_generator = IdGenerator(max_value=999)
+
+
 class ProcessHandler:
     def __init__(self, user, pty=False):
         self.pty = pty
-        self.id = str(id(self))
+        self.id = id_generator.create()
         assert user_exists(user)
         self.user = user
+        self.on_display_activity = None
 
-    async def start(self, command, work_dir=None, env={}):
+    async def start(self, command, work_dir=None, env={}, novnc=False):
         self.work_dir = work_dir or get_working_directory(self.user)
+        self.novnc = novnc
 
         stdio = asyncio.subprocess.PIPE
 
@@ -68,10 +75,14 @@ class ProcessHandler:
             process_env["PWD"] = self.work_dir
             process_env["USER"] = self.user
 
-        # Ensure that DISPLAY is set, so that user can open GUI windows
-        display = get_first_display()
-        if display is not None:
-            process_env["DISPLAY"] = display
+        # set $DISPLAY so that user can open GUI windows
+        if self.novnc:
+            process_env["DISPLAY"] = f":{self.id}"
+            await start_vnc(self.id, self.on_display_activity)
+        else:
+            default_display = get_first_display()
+            if default_display:
+                process_env["DISPLAY"] = default_display
 
         def preexec():
             if self.user != get_current_user():
@@ -190,6 +201,7 @@ class ProcessHandler:
         await timeout(self.ipc_tasks, 0.1)
 
         await self._clean_up()
+
         self.process = None
 
         if self.on_stop:
@@ -206,14 +218,22 @@ class ProcessHandler:
         )
 
     async def _clean_up(self):
-        try:
-            if self.pty:
+        if self.pty:
+            try:
                 self.pty_master.close()
                 self.pty_slave.close()
                 os.remove(self.pty_master)
                 os.remove(self.pty_slave)
-        except Exception:
-            pass
+            except Exception:
+                pass
+
+        if self.novnc:
+            try:
+                await stop_vnc(self.id)
+            except Exception:
+                pass
 
         for channel in SERVER_IPC_CHANNELS:
             ipc_cleanup(channel, pgid=self.pgid)
+
+        id_generator.free(self.id)

--- a/further_link/runner/py_process_handler.py
+++ b/further_link/runner/py_process_handler.py
@@ -10,7 +10,7 @@ dirname = pathlib.Path(__file__).parent.absolute()
 
 
 class PyProcessHandler(ProcessHandler):
-    async def start(self, path, code=None):
+    async def start(self, path, code=None, novnc=False):
         path = get_absolute_path(path, get_working_directory(self.user))
 
         # create path directories if they don't already exist
@@ -28,7 +28,7 @@ class PyProcessHandler(ProcessHandler):
 
         work_dir = os.path.dirname(entrypoint)
 
-        await super().start(command, work_dir)
+        await super().start(command, work_dir, novnc=novnc)
 
     async def _clean_up(self):
         try:

--- a/further_link/runner/shell_process_handler.py
+++ b/further_link/runner/shell_process_handler.py
@@ -5,10 +5,10 @@ from .process_handler import ProcessHandler
 
 
 class ShellProcessHandler(ProcessHandler):
-    async def start(self, path, code=None):
+    async def start(self, path, code=None, novnc=False):
         work_dir = get_absolute_path(path, get_working_directory(self.user))
 
         # create work dir if it doesn't already exist
         os.makedirs(work_dir, exist_ok=True)
 
-        await super().start(get_shell(self.user), work_dir)
+        await super().start(get_shell(self.user), work_dir, novnc=novnc)

--- a/further_link/util/display_activity_monitor.py
+++ b/further_link/util/display_activity_monitor.py
@@ -1,0 +1,58 @@
+import asyncio
+import logging
+from typing import Callable, List, Optional, Union
+
+
+class DisplayActivityMonitor:
+    display_number: int
+    callbacks: List
+    current_activity: Union[None, str]
+    on_display_activity: Optional[Callable]
+    _stop: bool
+    _monitor_task: Optional[asyncio.Task]
+    SLEEP_TIME = 1
+
+    def __init__(self, display_number: int) -> None:
+        self.display_number = display_number
+        self.callbacks = []
+        self.current_activity = None
+        self.on_display_activity = None
+        self._stop = False
+        self._monitor_task = None
+
+    def start(self) -> None:
+        self._monitor_task = asyncio.create_task(self._monitor())
+
+    async def _monitor(self) -> None:
+        logging.debug(
+            f"Starting to monitor for activity on display '{self.display_number}'"
+        )
+        self._stop = False
+        self.current_activity = await self._get_number_of_windows()
+
+        while not self._stop:
+            current_windows = await self._get_number_of_windows()
+            if current_windows and current_windows != self.current_activity:
+                logging.debug(f"Activity detected on display '{self.display_number}'")
+                self.current_activity = current_windows
+                if callable(self.on_display_activity):
+                    await self.on_display_activity()
+            await asyncio.sleep(self.SLEEP_TIME)
+
+    async def _get_number_of_windows(self):
+        proc = await asyncio.create_subprocess_shell(
+            f"xwininfo -d :{self.display_number} -root -tree",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        return stdout
+
+    async def stop(self) -> None:
+        logging.debug(
+            f"Stopping checks for activity on display '{self.display_number}'"
+        )
+        self._stop = True
+        if self._monitor_task:
+            self._monitor_task.cancel()
+            await asyncio.wait(self._monitor_task)

--- a/further_link/util/id_generator.py
+++ b/further_link/util/id_generator.py
@@ -1,0 +1,26 @@
+from random import randint
+from typing import List
+
+
+class IdGenerator:
+    used_ids: List
+    MAX_VALUE: int
+
+    def __init__(self, max_value: int) -> None:
+
+        self.used_ids = []
+        self.MAX_VALUE = max_value
+
+    def create(self) -> int:
+        if len(self.used_ids) == self.MAX_VALUE:
+            raise Exception("All ids are in use.")
+
+        candidate = randint(1, self.MAX_VALUE)
+        while candidate in self.used_ids:
+            candidate = randint(1, self.MAX_VALUE)
+        self.used_ids.append(candidate)
+        return candidate
+
+    def free(self, id) -> None:
+        if id in self.used_ids:
+            self.used_ids.remove(id)

--- a/further_link/util/ipc.py
+++ b/further_link/util/ipc.py
@@ -16,6 +16,8 @@ def _get_temp_dir():
     return os.environ.get("FURTHER_LINK_TEMP_DIR", "/tmp")
 
 
+# pgid is used to match up the ipc servers and clients, as it's something the
+# server knows about the process and the process can look up by itself
 def _get_ipc_channel_key(channel, pgid=None):
     if pgid is None:
         pgid = os.getpgid(os.getpid())

--- a/further_link/util/sdk.py
+++ b/further_link/util/sdk.py
@@ -33,7 +33,7 @@ def get_list_of_displays() -> List[str]:
 
 
 def get_first_display() -> Optional[str]:
-    displays = get_list_of_displays()
+    displays = sorted(get_list_of_displays())
     first_display = displays[0] if len(displays) > 0 else None
     return first_display
 

--- a/further_link/util/ssl_context.py
+++ b/further_link/util/ssl_context.py
@@ -2,6 +2,8 @@ import codecs
 import os
 import ssl
 
+from OpenSSL.crypto import FILETYPE_PEM, dump_privatekey, load_privatekey
+
 tls_exception = Exception(
     """
     TLS configuration error!
@@ -11,33 +13,59 @@ tls_exception = Exception(
 )
 
 
+class SslFiles:
+    def __init__(self) -> None:
+        file_dir = os.path.dirname(os.path.realpath(__file__))
+        cert_dir = os.path.join(file_dir, "../extra")
+
+        self.cert = os.path.join(cert_dir, "cert.pem")
+        self.own_key = os.path.join(cert_dir, "key.pem")
+        self.encrypted_key = os.path.join(cert_dir, "key.aes.pem")
+        self.data_file = os.path.join(cert_dir, "fl.dat")
+
+
 def ssl_context():
     # use ssl if FURTHER_LINK_NOSSL is unset, 0 or false
     if os.environ.get("FURTHER_LINK_NOSSL", "0").lower() not in ["0", "false"]:
         return None
 
     context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-
-    file_dir = os.path.dirname(os.path.realpath(__file__))
-    cert_dir = os.path.join(file_dir, "../extra")
-    cert = os.path.join(cert_dir, "cert.pem")
-    own_key = os.path.join(cert_dir, "key.pem")
-    encrypted_key = os.path.join(cert_dir, "key.aes.pem")
-    data_file = os.path.join(cert_dir, "fl.dat")
+    ssl_files = SslFiles()
 
     try:
-        if os.path.isfile(own_key):
-            context.load_cert_chain(certfile=cert, keyfile=own_key)
+        if os.path.isfile(ssl_files.own_key):
+            context.load_cert_chain(certfile=ssl_files.cert, keyfile=ssl_files.own_key)
         else:
-
-            def password():
-                with open(data_file) as file:
-                    return codecs.getencoder("rot-13")(file.read()[:-1])[0]
-
             context.load_cert_chain(
-                certfile=cert, keyfile=encrypted_key, password=password
+                certfile=ssl_files.cert,
+                keyfile=ssl_files.encrypted_key,
+                password=lambda: password(ssl_files),
             )
     except (FileNotFoundError, ssl.SSLError):
         raise tls_exception from None
 
     return context
+
+
+def password(ssl_files: SslFiles):
+    with open(ssl_files.data_file) as file:
+        return codecs.getencoder("rot-13")(file.read()[:-1])[0]
+
+
+def private_key(ssl_files: SslFiles):
+    with open(ssl_files.encrypted_key, "rb") as f:
+        buffer = f.read()
+
+    key = load_privatekey(
+        type=FILETYPE_PEM, buffer=buffer, passphrase=f"{password(ssl_files)}".encode()
+    )
+
+    return dump_privatekey(
+        type=FILETYPE_PEM, pkey=key, passphrase=f"{password(ssl_files)}".encode()
+    )
+
+
+def cert(ssl_files: SslFiles):
+    with open(ssl_files.cert, "rb") as f:
+        cert = f.read()
+    return cert

--- a/further_link/util/vnc.py
+++ b/further_link/util/vnc.py
@@ -1,0 +1,83 @@
+import asyncio
+import logging
+from typing import Callable
+from urllib.parse import urlparse
+
+from .display_activity_monitor import DisplayActivityMonitor
+
+display_activity_monitors = {}
+
+
+class VncConnectionDetails:
+    def __init__(self, url) -> None:
+        self._parsed_url = urlparse(url)
+
+    @property
+    def port(self):
+        return self._parsed_url.port
+
+    @property
+    def path(self):
+        return f"{self._parsed_url.path}?{self._parsed_url.query}"
+
+
+async def start_vnc(id: int, on_display_activity: Callable) -> None:
+    proc = await asyncio.create_subprocess_shell(
+        f"further-link-vnc start {id} {VNC_CERTIFICATE_PATH}",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    logging.info(f"Starting further-link-vnc on display '{id}'")
+    await proc.wait()
+
+    activity_monitor = DisplayActivityMonitor(id)
+
+    async def on_monitor_activity():
+        if not callable(on_display_activity):
+            return
+
+        connection_details = await vnc_connection_details(id)
+        if connection_details:
+            await on_display_activity(connection_details)
+
+    display_activity_monitors[id] = activity_monitor
+    activity_monitor.on_display_activity = on_monitor_activity
+    activity_monitor.start()
+
+
+async def stop_vnc(id: int) -> None:
+    proc = await asyncio.create_subprocess_shell(
+        f"further-link-vnc stop {id}",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    logging.info(f"Stopping further-link-vnc on display '{id}'")
+    await proc.wait()
+
+    activity_monitor = display_activity_monitors.get(id)
+    if activity_monitor:
+        await activity_monitor.stop()
+        display_activity_monitors.pop(id)
+
+
+async def vnc_connection_details(id: int):
+    proc = await asyncio.create_subprocess_shell(
+        f"further-link-vnc url {id}",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    novnc_url, _ = await proc.communicate()
+    return VncConnectionDetails(url=novnc_url.decode().strip())
+
+
+def create_ssl_certificate() -> None:
+    vnc_cert = Path(VNC_CERTIFICATE_PATH)
+    if vnc_cert.exists():
+        return
+    vnc_cert.touch(exist_ok=True)
+
+    ssl_files = SslFiles()
+    with open(VNC_CERTIFICATE_PATH, "w") as f:
+        for data in (cert(ssl_files), private_key(ssl_files)):
+            f.write(data.decode("utf-8"))

--- a/further_link/util/vnc.py
+++ b/further_link/util/vnc.py
@@ -1,11 +1,15 @@
 import asyncio
 import logging
+from pathlib import Path
 from typing import Callable
 from urllib.parse import urlparse
 
-from .display_activity_monitor import DisplayActivityMonitor
+from further_link.util.display_activity_monitor import DisplayActivityMonitor
+from further_link.util.ssl_context import SslFiles, cert, private_key
 
 display_activity_monitors = {}
+
+VNC_CERTIFICATE_PATH = "/tmp/.further_link.vnc_ssl.pem"
 
 
 class VncConnectionDetails:

--- a/scripts/further-link-vnc
+++ b/scripts/further-link-vnc
@@ -1,0 +1,101 @@
+#!/bin/bash
+###############################################################
+#                Unofficial 'Bash strict mode'                #
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/  #
+###############################################################
+set -euo pipefail
+IFS=$'\n\t'
+###############################################################
+
+
+do_start() {
+    # Start virtual display
+    echo "Starting virtual display ${VIRTUAL_DISPLAY_ID}..."
+    Xvfb ":${VIRTUAL_DISPLAY_ID}" -screen 1 480x640x16 &
+    echo "Xvfb PID is $!"
+    PIDS="$!"
+
+    echo "Starting x11vnc using port ${VNC_PORT}..."
+    x11vnc -rfbport "${VNC_PORT}"  -bg -forever -shared -display ":${VIRTUAL_DISPLAY_ID}" -nopw -ncache
+    echo "x11vnc PID is $!"
+    PIDS+=("$!")
+
+    echo "Starting novnc server using http port ${HTTP_PORT}..."
+    novnc_command="/usr/share/novnc/utils/launch.sh  --listen ${HTTP_PORT} --vnc localhost:${VNC_PORT}"
+    if [ -f "${SSL_CERT}" ]; then
+        echo "Using certificate in ${SSL_CERT}"
+        novnc_command+=" --cert ${SSL_CERT}"
+    fi
+    novnc_command+=" &"
+    eval "${novnc_command}"
+
+    echo "novnc PID is $!"
+    PIDS+=("$!")
+
+    echo "Storing PIDs into ${PIDS_FILE}"
+    printf "%s\n" "${PIDS[@]}" > "${PIDS_FILE}"
+}
+
+
+do_stop() {
+    if [ -f "${PIDS_FILE}" ]; then
+        # Kill PIDs of processes associated with VIRTUAL_DISPLAY_ID
+        echo "Found PIDs file ${PIDS_FILE}"
+        while read PID ; do
+            echo "Killing PID ${PID}..."
+            kill -9 "${PID}" || true
+        done < "${PIDS_FILE}"
+
+        echo "Removing ${PIDS_FILE}"
+        rm -r "${PIDS_FILE}"
+    else
+        echo "No PID file for display ${VIRTUAL_DISPLAY_ID}, skipping..."
+    fi
+}
+
+
+get_url() {
+    echo "http://pi-top.local:${HTTP_PORT}/vnc.html?autoconnect=true"
+}
+
+
+if [ "$#" -gt "4" ]; then
+    echo -e "Usage:\n\tfurther-link-vnc <COMMAND> <DISPLAY_ID> <SSL_CERTIFICATE>"
+    echo "where:"
+    echo -e "\tCOMMAND: start, stop, url."
+    echo -e "\tDISPLAY_ID: integer, id for the virtual display to create."
+    echo -e "\tSSL_CERTIFICATE: path to combined cert/key file. Optional."
+    exit 1
+fi
+
+
+COMMAND="${1}"
+
+# Pad display id to have 3 digits
+VIRTUAL_DISPLAY_ID=$(printf "%03d" ${2})
+
+SSL_CERT=""
+if [ "$#" -ge "3" ]; then
+    SSL_CERT="${3}"
+fi
+
+VNC_PORT="40${VIRTUAL_DISPLAY_ID}"
+HTTP_PORT="60${VIRTUAL_DISPLAY_ID}"
+PIDS_FILE="/tmp/.further-link-vnc.${VIRTUAL_DISPLAY_ID}.pid"
+
+
+case "${COMMAND}" in
+    start)
+        do_start
+        ;;
+    stop)
+        do_stop
+        ;;
+    url)
+        get_url
+        ;;
+    *)
+        echo "Unknown argument \`${1}'" >&2
+        exit 1
+        ;;
+esac

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,8 @@ install_requires =
     aiohttp_cors>=0.7.0,<0.8.0
     numpy>=1.19.5,<1.20
     Pillow>=8.1.2,<8.2
+    pyOpenSSL>=20.0.0,<21.0.0
+
 include_package_data = True
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     aiohttp_cors>=0.7.0,<0.8.0
     numpy>=1.19.5,<1.20
     Pillow>=8.1.2,<8.2
-    pyOpenSSL>=20.0.0,<21.0.0
+    pyOpenSSL>=19.0.0,<21.0.0
 
 include_package_data = True
 
@@ -50,6 +50,7 @@ test =
     pytest-timeout
     pytest-aiohttp
     aioresponses
+    testpath
 
 [options.entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 import setuptools
 
 if __name__ == "__main__":
-    setuptools.setup()
+    setuptools.setup(scripts=["scripts/further-link-vnc"])

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -13,14 +13,14 @@ async def receive_data(ws, channel, data_key=None, data_value=None, process=""):
     while (not isinstance(data_value, str)) or len(received) < len(data_value):
         m_type, m_data, m_process = parse_message((await ws.receive()).data)
 
-        assert m_process == process, f"{m_process} != {process}"
+        assert m_process == process, f"{m_process} != {process}, {m_type}, {m_data}"
         assert m_type == channel, f"{m_type} != {channel}\ndata: {m_data}"
 
         # return if not looking for specific data
         if data_key is None:
             return
 
-        assert m_data.get(data_key) is not None
+        assert m_data.get(data_key) is not None, f"{m_data}"
 
         # if data_value is not string, it should all come in one go
         if not isinstance(data_value, str):
@@ -49,7 +49,7 @@ async def wait_for_data(
             if data_key is None:
                 return
 
-            assert m_data.get(data_key, None) is not None
+            assert m_data.get(data_key) is not None, f"{m_data}"
 
             if data_value is None:
                 return

--- a/tests/e2e/test_run_lib.py
+++ b/tests/e2e/test_run_lib.py
@@ -41,7 +41,6 @@ color('red')
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="Temporarily disabled - to be fixed")
 async def test_keyevent(run_ws_client):
     code = """\
 from further_link import KeyboardButton

--- a/tests/e2e/test_run_py.py
+++ b/tests/e2e/test_run_py.py
@@ -339,7 +339,6 @@ color('red')
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="Temporarily disabled - to be fixed")
 async def test_keyevent(run_py_ws_client):
     code = """\
 from further_link import KeyboardButton

--- a/tests/unit/test_process_handler.py
+++ b/tests/unit/test_process_handler.py
@@ -28,14 +28,9 @@ async def test_basic():
     p.on_stop = AsyncMock()
     p.on_output = AsyncMock()
 
-    # TODO this is too fast to even lookup the pgid?!
-    # await p.start("echo 'hello world'")
-
-    # TODO this is too fast to capture the output
-    # WIP fix on branch improve-output-handling setting up output before start
-    # await p.start("bash -c \"echo 'hello world'\"")
-
-    await p.start("python3 -c \"print('hello world')\"")
+    # this is fast, won't have time to get it's pgid and set up ipc, but we
+    # should get the output still
+    await p.start("echo 'hello world'")
 
     assert type(p.process) == Process
     p.on_start.assert_called()

--- a/tests/unit/test_process_handler.py
+++ b/tests/unit/test_process_handler.py
@@ -28,18 +28,23 @@ async def test_basic():
     p.on_stop = AsyncMock()
     p.on_output = AsyncMock()
 
-    # is this too fast to even lookup the pgid?!
-    # await p.start("echo 'hello\nworld'")
+    # TODO this is too fast to even lookup the pgid?!
+    # await p.start("echo 'hello world'")
 
-    await p.start("bash -c \"echo 'hello\nworld'\"")
+    # TODO this is too fast to capture the output
+    # WIP fix on branch improve-output-handling setting up output before start
+    # await p.start("bash -c \"echo 'hello world'\"")
+
+    await p.start("python3 -c \"print('hello world')\"")
+
     assert type(p.process) == Process
     p.on_start.assert_called()
 
     await p.process.wait()
-    # takes some time to complete - there's a 0.1 sleep in there
+    # takes some time to complete - 0.1s output buffer etc
     await asyncio.sleep(0.2)
 
-    p.on_output.assert_called_with("stdout", "hello\nworld\n")
+    p.on_output.assert_called_with("stdout", "hello world\n")
     p.on_stop.assert_called_with(0)
 
 

--- a/tests/unit/test_process_handler.py
+++ b/tests/unit/test_process_handler.py
@@ -8,6 +8,7 @@ from asyncio.subprocess import Process
 import pytest
 from aiofiles.threadpool.binary import AsyncFileIO
 from mock import AsyncMock
+from testpath import MockCommand
 
 from further_link.runner.process_handler import ProcessHandler
 
@@ -50,7 +51,7 @@ async def test_input():
     p.on_stop = AsyncMock()
     p.on_output = AsyncMock()
 
-    await p.start('python3 -c "print(input())"')
+    await p.start('python3 -u -c "print(input())"')
     p.on_start.assert_called()
 
     await p.send_input("hello\n")
@@ -71,7 +72,7 @@ async def test_pty():
     p.on_stop = AsyncMock()
     p.on_output = AsyncMock()
 
-    await p.start('python3 -c "print(input())"')
+    await p.start('python3 -u -c "print(input())"')
     assert type(p.process) == Process
     assert p.pty
     assert type(p.pty_master) == AsyncFileIO
@@ -87,3 +88,48 @@ async def test_pty():
 
     p.on_output.assert_called_with("stdout", "hello\r\nhello\r\n")
     p.on_stop.assert_called_with(0)
+
+
+@pytest.mark.asyncio
+async def test_novnc():
+    p = ProcessHandler(user)
+
+    p.on_start = AsyncMock()
+    p.on_stop = AsyncMock()
+    p.on_output = AsyncMock()
+    p.on_display_activity = AsyncMock()
+
+    code = """\
+from signal import pause
+print('doing fake graphics!')
+pause()
+"""
+
+    with MockCommand("further-link-vnc") as fl_vnc:
+        await p.start(f'python3 -u -c "{code}"', novnc=True)
+
+    fl_vnc.assert_called(["start", str(p.id), "/tmp/.further_link.vnc_ssl.pem"])
+    p.on_start.assert_called()
+
+    with MockCommand.fixed_output("xwininfo", "no window") as xwininfo:
+        await asyncio.sleep(0.2)  # wait for display monitor to find this
+
+    xwininfo.assert_called()
+
+    with MockCommand.fixed_output("xwininfo", "new window") as xwininfo:
+        with MockCommand("further-link-vnc") as fl_vnc:
+            await asyncio.sleep(2)  # wait for display monitor to find this
+
+    xwininfo.assert_called()
+    fl_vnc.assert_called(["url", str(p.id)])
+    p.on_display_activity.assert_called()
+
+    with MockCommand("further-link-vnc") as fl_vnc:
+        await p.stop()
+        await p.process.wait()
+        # takes some time to complete - there's a 0.1 sleep in there
+        await asyncio.sleep(0.2)
+
+    p.on_output.assert_called_with("stdout", "doing fake graphics!\n")
+    fl_vnc.assert_called(["stop", str(p.id)])
+    p.on_stop.assert_called_with(-15)


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/FUR-2486) |


#### Main changes

Add backend to create and serve VNC over http(s) on further:
- Whenever a message is received via websockets with `'novnc': true`, a virtual display will be created (using `Xvfb`), a VNC server will publish it (using `x11vnc`) and will be accessible via web-browser (using `novnc`).
- Whenever activity is detected in a virtual display, a message will be sent to the frontend with connection details.
- When the received code stops, the virtual display is cleaned up.
- All of these tasks are performed by the `further-link-vnc` bash script.
- `novnc` serves the VNC server over https with a SSL certificate created on app start. 

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips

- Install artifacts
- Send a command via websocket using the new `novnc` arg, such as:
```
{ "type": "start", "process": "1", "data": { "runner": "python3", "code": "print('hi'); from time import sleep; import turtle; turtle.Screen(); sleep(30); print('bye!')", "novnc": true } }
```

#### Tag anyone who definitely needs to review or help
-
