### PR TITLE
Swe 84 set xdg runtime dir

### DIFF
--- a/further_link/runner/process_handler.py
+++ b/further_link/runner/process_handler.py
@@ -18,8 +18,10 @@ from ..util.user_config import (
     get_gid,
     get_grp_ids,
     get_home_directory,
+    get_shell,
     get_uid,
     get_working_directory,
+    get_xdg_runtime_dir,
     user_exists,
 )
 from ..util.vnc import VNC_CERTIFICATE_PATH
@@ -74,10 +76,14 @@ class ProcessHandler:
         process_env["TERM"] = "xterm-256color"  # perhaps should be param
 
         if self.user:
-            process_env["HOME"] = get_home_directory(self.user)
-            process_env["LOGNAME"] = self.user
-            process_env["PWD"] = self.work_dir
             process_env["USER"] = self.user
+            process_env["LOGNAME"] = self.user
+            process_env["HOME"] = get_home_directory(self.user)
+            process_env["XDG_RUNTIME_DIR"] = get_xdg_runtime_dir(self.user)
+            process_env["SHELL"] = get_shell(self.user)
+            process_env["PWD"] = self.work_dir
+            # remove None values
+            process_env = {k: v for k, v in process_env.items() if v is not None}
 
         # set $DISPLAY so that user can open GUI windows
         if self.novnc:

--- a/further_link/util/user_config.py
+++ b/further_link/util/user_config.py
@@ -79,6 +79,16 @@ def get_working_directory(user=None):
     return os.path.join(get_home_directory(user), DEFAULT_DIR_NAME)
 
 
+def get_xdg_runtime_dir(user=None):
+    uid = get_uid(user)
+    xdg_runtime_dir = f"/run/user/{uid}"
+
+    if os.path.exists(xdg_runtime_dir):
+        return xdg_runtime_dir
+
+    return None
+
+
 def get_absolute_path(path, root="/"):
     # path is absolute or relative to root
     is_absolute = path[0] == "/"

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     numpy>=1.19.5,<1.20
     Pillow>=8.1.2,<8.2
     pt_web_vnc
-    pyOpenSSL>=19.0.0,<21.0.0
+    pyOpenSSL>=22.0.0,<23.0.0
 
 include_package_data = True
 


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready | [Ticket](https://pi-top.atlassian.net/browse/SWE-84) |


#### Main changes
- Set XDG_RUNTIME_DIR and SHELL when switching user. I added shell because that's one that su and sudo set when switching user which we were missing.  XDG_RUNTIME_DIR  is done by su as part of pam login

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
- Ensure env dict does not contain None values which will raise when being set
- I conditionally enabled the test for switching user, it runs in CI but won't in many environments. I had to test a shell script instead of python as the test coverage collector seems to inject stuff into all python processes which doesn't work when it's not running as the expected user.
- Upgrade pyOpenSSL due install [error](https://github.com/pi-top/Further-Link/actions/runs/3099140645/jobs/5017920124)

#### Manual testing tips
- When running code via further-link XDG_RUNTIME_DIR   should be set, meaning `aplay` outputs audio to the correct device

