### PR TITLE
Set PYTHON_PACKAGE_VERSION when building docker image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,16 +28,20 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      - name: Parse changelog version number
+        run: |
+          sudo apt install -y dpkg-dev
+          echo "VERSION=$(dpkg-parsechangelog -Sversion)" >> $GITHUB_ENV
+
       - name: Generate human-readable non-release tag
         if: github.event_name != 'release' || github.event.action != 'created'
         run: |
           echo "DOCKER_TAG=$(basename ${GITHUB_HEAD_REF:-$GITHUB_REF})-$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
 
-      - name: Generate release tag
+      - name: Use version in release tag
         if: github.event_name == 'release' && github.event.action == 'created'
         run: |
-          sudo apt install -y dpkg-dev
-          echo "DOCKER_TAG=v$(dpkg-parsechangelog -Sversion)" >> $GITHUB_ENV
+          echo "DOCKER_TAG=v${{ env.VERSION }}" >> $GITHUB_ENV
 
       - name: Build and push
         id: docker_build_push
@@ -46,6 +50,8 @@ jobs:
           context: .
           push: true
           tags: "pitop/pt-further-link:${{ env.DOCKER_TAG }}"
+          build-args: |
+            PYTHON_PACKAGE_VERSION=${{ env.VERSION }}
 
       - name: Show image digest
         run: echo ${{ steps.docker_build_push.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:bullseye
 
+ARG PYTHON_PACKAGE_VERSION
+
 # Install pip3 and python3 with tk graphics
 RUN apt-get update && \
     apt-get install -y python3-tk python3-pip && \
@@ -35,6 +37,7 @@ RUN pip3 install .
 
 ENV FURTHER_LINK_NOSSL=true
 ENV PYTHONUNBUFFERED=1
+ENV PYTHON_PACKAGE_VERSION=$PYTHON_PACKAGE_VERSION
 
 EXPOSE 8028
 EXPOSE 60100-60999


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready | [Related Ticket](https://pi-top.atlassian.net/browse/OS-1313) |


#### Main changes
- Set PYTHON_PACKAGE_VERSION inside the docker images so that their /version endpoint responds with the correct version