### PR TITLE
feat: upload endpoint skips downloading urls when offline

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,8 +54,10 @@ For more information related to the `run-py` API see the options of the
 - Body should be a JSON object with `name` of directory to upload into and
   `files` object. Files are provided as `text` type, with the text content, or
   `url` type, with a url for the file to be downloaded from
-  ([example](../tests/test_data/upload_data.py)). Responds after creating files is
-  complete with a simple 200 OK.
+  ([example](../tests/test_data/upload_data.py)). If the server does not have
+  internet access then url type files will be ignored. Reponse is a json
+  which includes whether the url type files were downloaded:
+  `{ "success": true, "fetched_urls": true }`.
 
 ### Websocket Endpoint /run-py
 Each websocket client connected on `/run-py` can manage a single python process

--- a/further_link/endpoint/upload.py
+++ b/further_link/endpoint/upload.py
@@ -27,7 +27,7 @@ async def upload(request):
         if not directory_is_valid(directory):
             raise web.HTTPBadRequest(reason=f"Invalid upload directory: {directory}")
 
-        await do_upload(directory, work_dir, user)
+        fetched_urls = await do_upload(directory, work_dir, user)
 
         if is_miniscreen_project(directory.get("files", {})):
             await do_copy_files_to_projects_directory(
@@ -44,4 +44,6 @@ async def upload(request):
         logging.exception(e)
         raise web.HTTPInternalServerError()
 
-    return web.Response(text="OK")
+    return web.Response(
+        text=json.dumps({"success": True, "fetched_urls": fetched_urls})
+    )

--- a/tests/e2e/test_run_py_upload.py
+++ b/tests/e2e/test_run_py_upload.py
@@ -93,6 +93,7 @@ print(call_some_lib())
 
 @pytest.mark.asyncio
 async def test_upload_bad_file(run_py_ws_client, aioresponses):
+    aioresponses.head("https://google.com", status=200)
     aioresponses.add("https://placekitten.com/50/50", status=500)
 
     upload_cmd = create_message("upload", {"directory": directory})


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready| [no Ticket] |


#### Main changes
- feat: upload endpoint skips downloading urls when offline
Upload response is now a json with success: true and a boolean field
fetched_urls which indicates wether urls were fetched or skipped.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
