### PR TITLE
fix: set response header Access-Control-Allow-Private-Network to true

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
 RUN git clone https://github.com/pi-top/pi-topOS-Apt-Source.git && \
     cd pi-topOS-Apt-Source && \
     cp keys/* /usr/share/keyrings/ && \
-    cp sources/pi-top-os.list /etc/apt/sources.list.d/ && \
+    usr/lib/pi-top-os-apt-installer/pi-top-apt-source-manager install pi-top-os && \
     apt-get update && \
     rm -rf /pi-topOS-Apt-Source
 

--- a/further_link/__main__.py
+++ b/further_link/__main__.py
@@ -43,6 +43,11 @@ async def create_bluetooth_app() -> Optional[BluetoothServer]:
 async def create_web_app():
     app = web.Application()
 
+    async def set_extra_cors_headers(request, response):
+        response.headers["Access-Control-Allow-Private-Network"] = "true"
+
+    app.on_response_prepare.append(set_extra_cors_headers)
+
     cors = aiohttp_cors.setup(
         app,
         defaults={

--- a/tests/e2e/test_http.py
+++ b/tests/e2e/test_http.py
@@ -13,6 +13,7 @@ from . import STATUS_PATH, VERSION_PATH
 async def test_status(http_client):
     response = await http_client.get(STATUS_PATH)
     assert response.status == 200
+    assert response.headers["Access-Control-Allow-Private-Network"] == "true"
     assert await response.text() == "OK"
 
 


### PR DESCRIPTION
This is a new cors header that is required when you set the chrome flag 'Experimental Web Platform features'. We may use that flag for bluetooth etc. This header isn't yet supported by our CORS lib etc, so this seems to be an OK way of adding it.

| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/<ticket-number>) |


#### Main changes
-

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
