### PR TITLE
Set pretty hostname on service start

### DIFF
--- a/debian/further-link.lintian-overrides
+++ b/debian/further-link.lintian-overrides
@@ -2,3 +2,4 @@ further-link: no-manual-page usr/bin/further-link
 further-link: no-manual-page usr/bin/start-further
 further-link: no-manual-page usr/bin/further-link-bluetooth-pairing
 further-link: no-manual-page usr/bin/further-link-bluetooth-encryption
+further-link: no-manual-page usr/bin/further-link-set-pretty-hostname

--- a/debian/further-link.service
+++ b/debian/further-link.service
@@ -7,6 +7,7 @@ After=network.target
 Type=simple
 Environment="PYTHONUNBUFFERED=1"
 Environment="PYTHONDONTWRITEBYTECODE=1"
+ExecStartPre=/usr/bin/further-link-set-pretty-hostname
 ExecStart=/usr/bin/further-link
 
 [Install]

--- a/further_link/endpoint/apt_version.py
+++ b/further_link/endpoint/apt_version.py
@@ -1,10 +1,9 @@
 import json
 import re
-from os import environ
-from shlex import split
-from subprocess import run
 
 from aiohttp import web
+
+from ..util.sdk import run_command
 
 
 def _apt_version_dict(package):
@@ -27,25 +26,5 @@ def apt_cache_installed(pkg_name):
         output = run_command(command)
         match = re.search("Installed: (.*)", output)
         return match.group(1) if match else None
-    except Exception:
-        return None
-
-
-def run_command(command_str):
-    def __get_env():
-        env = environ.copy()
-        # Print output of commands in english
-        env["LANG"] = "en_US.UTF-8"
-        return env
-
-    try:
-        resp = run(
-            split(command_str),
-            check=False,
-            capture_output=True,
-            timeout=5,
-            env=__get_env(),
-        )
-        return str(resp.stdout, "utf8")
     except Exception:
         return None

--- a/further_link/util/hostname.py
+++ b/further_link/util/hostname.py
@@ -1,0 +1,15 @@
+import logging
+
+import click
+
+from .bluetooth.utils import get_bluetooth_server_name
+from .sdk import run_command
+
+
+@click.command()
+def set_pretty_hostname() -> None:
+    try:
+        name = get_bluetooth_server_name()
+        run_command(f"hostnamectl set-hostname --pretty {name}")
+    except Exception as e:
+        logging.error(f"Error setting pretty hostname: {e}")

--- a/further_link/util/sdk.py
+++ b/further_link/util/sdk.py
@@ -7,6 +7,7 @@
 
 from glob import glob
 from os import environ
+from shlex import split
 from subprocess import run
 from typing import List, Optional
 
@@ -80,3 +81,23 @@ class Singleton(type):
         if cls.instance is None:
             cls.instance = super(Singleton, cls).__call__(*args, **kwargs)
         return cls.instance
+
+
+def run_command(command_str):
+    def __get_env():
+        env = environ.copy()
+        # Print output of commands in english
+        env["LANG"] = "en_US.UTF-8"
+        return env
+
+    try:
+        resp = run(
+            split(command_str),
+            check=False,
+            capture_output=True,
+            timeout=5,
+            env=__get_env(),
+        )
+        return str(resp.stdout, "utf8")
+    except Exception:
+        return None

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ console_scripts =
     start-further=further_link.start_further:start_further
     further-link-bluetooth-pairing=further_link.util.bluetooth.pairing:main
     further-link-bluetooth-encryption=further_link.util.bluetooth.encryption:main
+    further-link-set-pretty-hostname=further_link.util.hostname:set_pretty_hostname
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/<ticket-number>) |


#### Main changes
On Apple devices, the pi-top GATT server isn't displayed with it's device name (pi-top-XXXX); it displays the device hostname (pi-top).

Setting a 'pretty' hostname fixes this issue; this solution avoids changing the 'real' hostname, which could bring networking issues in some cases.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
