### PR TITLE
fix: use the system CA bundle instead of the OpenSSL default CA file

### DIFF
--- a/debian/further-link.service
+++ b/debian/further-link.service
@@ -5,6 +5,7 @@ After=network.target
 
 [Service]
 Type=simple
+Environment="SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"
 Environment="PYTHONUNBUFFERED=1"
 Environment="PYTHONDONTWRITEBYTECODE=1"
 ExecStartPre=/usr/bin/further-link-set-pretty-hostname


### PR DESCRIPTION
On some wifi networks additional certificates must be installed and used. These additional certs are included in the system's CA bundle file at /etc/ssl/certs/ca-certificates.crt but further-link's aiohttp requests, such as when downloading file attachments from the code directory, use OpenSSL which was defaulting to it's own bundle at /usr/lib/ssl/cert.pem. SSL_CERT_FILE env var is used to override this.

| Status  | Ticket/Issue |
| :---: | :--: |
| Ready| [Ticket](https://pi-top.atlassian.net/browse/SWE-373) |


#### Main changes
-

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
