### PR TITLE
Add Bluetooth card status check and unlock when enabling pairing mode

### DIFF
--- a/.github/workflows/deb-build.yml
+++ b/.github/workflows/deb-build.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   check-architecture:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       architecture: ${{ steps.set-arch.outputs.architecture }}
     steps:
@@ -43,7 +43,7 @@ jobs:
           echo "architecture=$architecture">>$GITHUB_OUTPUT
 
   check-distro:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       distros: ${{ steps.set-distros.outputs.distros }}
     steps:
@@ -73,7 +73,7 @@ jobs:
 
   set-build-matrix:
     needs: [check-distro, check-architecture]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -85,7 +85,7 @@ jobs:
           echo "matrix=$matrix">>$GITHUB_OUTPUT
 
   build-debian-package:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: set-build-matrix
     strategy:
       fail-fast: false

--- a/.github/workflows/deb-release.yml
+++ b/.github/workflows/deb-release.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   check-architecture:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       architecture: ${{ steps.set-arch.outputs.architecture }}
     steps:
@@ -42,7 +42,7 @@ jobs:
           echo "architecture=$architecture">>$GITHUB_OUTPUT
 
   check-distro:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       distros: ${{ steps.set-distros.outputs.distros }}
     steps:
@@ -72,7 +72,7 @@ jobs:
 
   set-build-matrix:
     needs: [check-distro, check-architecture]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -85,7 +85,7 @@ jobs:
 
   check-versions:
     if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged && github.head_ref == 'bump-changelog')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       CURRENT_VERSION: ${{ steps.current_version.outputs.CURRENT_VERSION }}
     steps:
@@ -119,7 +119,7 @@ jobs:
 
   release:
     needs: [set-build-matrix, check-versions]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged && github.head_ref == 'bump-changelog')
     strategy:
       fail-fast: false

--- a/.github/workflows/deb-update-changelog.yml
+++ b/.github/workflows/deb-update-changelog.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   bump-changelog-on-pr:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     # if last commit was not a merge of the changelog
     # env vars can't be used in if checks
     if: ${{ ! contains(github.event.head_commit.message, 'New changelog entry:') }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-docker-image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test-and-upload-coverage-report:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/further_link/util/bluetooth/pairing.py
+++ b/further_link/util/bluetooth/pairing.py
@@ -12,12 +12,42 @@ from further_link.util.bluetooth.uuids import PT_SERVICE_UUID
 PAIRING_TIME = 60
 
 
+async def is_bt_card_blocked() -> bool:
+    """
+    Check if the BT card is blocked by checking if the adapter is powered on.
+    """
+    cmd = "rfkill list bluetooth -o Soft -n"
+    try:
+        process = await asyncio.create_subprocess_shell(cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+        stdout, _ = await process.communicate()
+        return stdout.decode().strip() == "blocked"
+    except Exception as e:
+        logging.error(f"Error checking if BT card is blocked: {e}")
+        return False
+
+async def unlock_bt_card() -> None:
+    """
+    Unlock the BT card using rfkill
+    """
+    command = "rfkill unblock bluetooth"
+    logging.info(f"Unlocking BT card using command: {command}")
+    try:
+        process = await asyncio.create_subprocess_shell(command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+        await process.communicate()
+    except Exception as e:
+        logging.error(f"Error unlocking BT card: {e}")
+
+
 async def pairing_mode():
     logging.info(
         f"Starting pairing mode and advertisement of {PT_SERVICE_UUID} for {PAIRING_TIME} seconds"
     )
     bus = await get_message_bus()
     adapter = await Adapter.get_first(bus)
+
+    if await is_bt_card_blocked():
+        logging.info("Bluetooth card is blocked, unlocking it...")
+        await unlock_bt_card()
 
     agent = NoIoAgent()
     await agent.register(bus)


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/<ticket-number>) |


#### Main changes
Check for bluetooth card status when enabling pairing mode and unblock if necessary.

This change is necessary since `raspberrypi-sys-mods` version `20241202` created `/etc/modprobe.d/rfkill_default.conf` with `options rfkill default_state=0` which means that `rfkill` is configured to disable all radio devices by default on boot

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
