### PR TITLE
Bluetooth server supports writes without response

### DIFF
--- a/further_link/util/bluetooth/service.py
+++ b/further_link/util/bluetooth/service.py
@@ -40,7 +40,7 @@ class SecureFlags:
 # Some OS doesn't support protected/secure characteristics
 class NonSecureFlags:
     READ = CharacteristicFlags.READ
-    WRITE = CharacteristicFlags.WRITE
+    WRITE = CharacteristicFlags.WRITE | CharacteristicFlags.WRITE_WITHOUT_RESPONSE
     NOTIFY = CharacteristicFlags.NOTIFY
 
 


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready | [Ticket](https://pi-top.atlassian.net/browse/SWE-399) |


#### Main changes
Bluetooth server supports writes without response.

This fixes an issue on bullseye where on the client some writes (even when they were 'writes with response') would fail, causing problems when connecting further and further-link.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
