### PR TITLE
fix: set allow_credentials to False so that we no longer see CORS err…

### DIFF
--- a/further_link/__main__.py
+++ b/further_link/__main__.py
@@ -51,11 +51,13 @@ async def create_web_app():
 
     app.on_response_prepare.append(set_extra_cors_headers)
 
+    # Configure CORS - allow all origins
+    # No credentials needed since this app doesn't use cookies or auth headers
     cors = aiohttp_cors.setup(
         app,
         defaults={
             "*": aiohttp_cors.ResourceOptions(
-                allow_credentials=True,
+                allow_credentials=False,
                 expose_headers="*",
                 allow_headers="*",
             )


### PR DESCRIPTION
…ors when accessing from IFrame

| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/<ticket-number>) |


#### Main changes
- Set allow_credentials to false because the wildcard cors configuration with allow credentials causes CORS errors when the accessing domain is not pi-top.com, e.g. when in Iframe

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
